### PR TITLE
Use superadmin as default user

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -3,8 +3,8 @@ package client
 // Config for all commands.
 type Config struct {
 	Domain   string `help:"Domain of the OpenSlides server to probe." short:"d" default:"localhost:8000"`
-	Username string `help:"Username for logged-in requests." short:"u" default:"admin"`
-	Password string `help:"Password to use for logged-in requests." short:"p" default:"admin"`
+	Username string `help:"Username for logged-in requests." short:"u" default:"superadmin"`
+	Password string `help:"Password to use for logged-in requests." short:"p" default:"superadmin"`
 	HTTP     bool   `help:"Use http instead of https. Default is https."`
 	IPv4     bool   `help:"Force IPv4 for requests." short:"4"`
 	FakeAuth bool   `help:"Do not login but expect user id 1."`


### PR DESCRIPTION
It is the default in the manage-service

@rrenkert Please be aware of this change. The development environment and the "manage-service" enviroment currently use different defaults. This is annoying. With this PR I change the default to the manage-service default.